### PR TITLE
Fixed bundle install

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://ruby.taobao.org'
+source 'https://ruby.taobao.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.0.0'


### PR DESCRIPTION
Error:

```
Fetching git://github.com/amatsuda/kaminari.git
Fetching git://github.com/ankane/searchkick.git
Fetching source index from http://ruby.taobao.org/
Could not fetch specs from http://ruby.taobao.org/
ERROR: Service 'webapp' failed to build: The command '/bin/sh -c bundle install --without development test doc --jobs=4' returned a non-zero code: 17
```
